### PR TITLE
[Breaking]: Don't return node.start & node.end

### DIFF
--- a/__tests__/src/getProp-parser-test.js
+++ b/__tests__/src/getProp-parser-test.js
@@ -61,25 +61,22 @@ function actualTest(parserName, test) {
 
   assert.deepStrictEqual(
     adjustLocations(sourceResult, offset),
-    adjustRangeStartAndEnd(targetResult),
+    adjustRange(targetResult),
   );
 }
 
-function adjustRangeStartAndEnd({ name, value: { expression, ...value }, ...node }) {
+function adjustRange({ name, value: { expression, ...value }, ...node }) {
   return {
-    ...adjustNodeRangeStartAndEnd(node),
-    name: adjustNodeRangeStartAndEnd(name),
+    ...adjustNodeRange(node),
+    name: adjustNodeRange(name),
     value: {
-      ...adjustNodeRangeStartAndEnd(value),
-      ...(expression
-        ? { expression: adjustNodeRangeStartAndEndRecursively(expression) }
-        : {}
-      ),
+      ...adjustNodeRange(value),
+      ...(expression ? { expression: adjustNodeRangeRecursively(expression) } : {}),
     },
   };
 }
 
-function adjustNodeRangeStartAndEnd(node) {
+function adjustNodeRange(node) {
   if (!node.loc) {
     return node;
   }
@@ -87,19 +84,19 @@ function adjustNodeRangeStartAndEnd(node) {
   const [start, end] = node.range || [node.start, node.end];
   return {
     ...node,
-    end,
+    end: undefined,
     range: [start, end],
-    start,
+    start: undefined,
   };
 }
 
-function adjustNodeRangeStartAndEndRecursively(node) {
+function adjustNodeRangeRecursively(node) {
   if (Array.isArray(node)) {
-    return node.map(adjustNodeRangeStartAndEndRecursively);
+    return node.map(adjustNodeRangeRecursively);
   }
 
   if (node && typeof node === 'object') {
-    return adjustNodeRangeStartAndEnd(mapValues(node, adjustNodeRangeStartAndEndRecursively));
+    return adjustNodeRange(mapValues(node, adjustNodeRangeRecursively));
   }
 
   return node;
@@ -143,7 +140,7 @@ function adjustNodeLocations(node, { startOffset, endOffset }) {
   const [start, end] = node.range || [];
   return {
     ...node,
-    end: node.end + endOffset,
+    end: undefined,
     loc: {
       ...node.loc,
       start: {
@@ -156,7 +153,7 @@ function adjustNodeLocations(node, { startOffset, endOffset }) {
       },
     },
     range: [start + startOffset, end + endOffset],
-    start: node.start + startOffset,
+    start: undefined,
   };
 }
 

--- a/src/getProp.js
+++ b/src/getProp.js
@@ -42,43 +42,37 @@ function propertyToJSXAttribute(node) {
     type: 'JSXAttribute',
     name: { type: 'JSXIdentifier', name: key.name, ...getBaseProps(key) },
     value: value.type === 'Literal'
-      ? adjustRangeStartAndEndOfNode(value)
-      : {
-        type: 'JSXExpressionContainer',
-        expression: adjustExpressionRangeStartAndEnd(value),
-        ...getBaseProps(value),
-      },
+      ? adjustRangeOfNode(value)
+      : { type: 'JSXExpressionContainer', expression: adjustExpressionRange(value), ...getBaseProps(value) },
     ...getBaseProps(node),
   };
 }
 
-function adjustRangeStartAndEndOfNode(node) {
+function adjustRangeOfNode(node) {
   const [start, end] = node.range || [node.start, node.end];
 
   return {
     ...node,
-    end,
+    end: undefined,
     range: [start, end],
-    start,
+    start: undefined,
   };
 }
 
-function adjustExpressionRangeStartAndEnd({ expressions, quasis, ...expression }) {
+function adjustExpressionRange({ expressions, quasis, ...expression }) {
   return {
-    ...adjustRangeStartAndEndOfNode(expression),
-    ...(expressions ? { expressions: expressions.map(adjustRangeStartAndEndOfNode) } : {}),
-    ...(quasis ? { quasis: quasis.map(adjustRangeStartAndEndOfNode) } : {}),
+    ...adjustRangeOfNode(expression),
+    ...(expressions ? { expressions: expressions.map(adjustRangeOfNode) } : {}),
+    ...(quasis ? { quasis: quasis.map(adjustRangeOfNode) } : {}),
   };
 }
 
 function getBaseProps({ loc, ...node }) {
-  const { end, range, start } = adjustRangeStartAndEndOfNode(node);
+  const { range } = adjustRangeOfNode(node);
 
   return {
-    end,
     loc: getBaseLocation(loc),
     range,
-    start,
   };
 }
 


### PR DESCRIPTION
BREAKING CHANGE: Nodes don't return the non-standard node.start & node.end anymore

As discussed in https://github.com/jsx-eslint/jsx-ast-utils/pull/97#issuecomment-630429265, this is the PR with the breaking change of not providing `node.start` & `node.end` anymore.