### PR TITLE
[Breaking] add `ChainExpression`; `CallExpression` now includes arguments

### DIFF
--- a/__tests__/src/elementType-test.js
+++ b/__tests__/src/elementType-test.js
@@ -11,7 +11,7 @@ describe('elementType tests', () => {
     const expected = 'function';
     const actual = typeof elementType;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should throw an error if the argument is missing', () => {
@@ -29,7 +29,7 @@ describe('elementType tests', () => {
     const expected = 'div';
     const actual = elementType(node);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct type of the custom element given its node object', () => {
@@ -39,7 +39,7 @@ describe('elementType tests', () => {
     const expected = 'Slider';
     const actual = elementType(node);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct type of the custom object element given its node object', () => {
@@ -49,7 +49,7 @@ describe('elementType tests', () => {
     const expected = 'UX.Slider';
     const actual = elementType(node);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct type of the namespaced element given its node object', () => {
@@ -59,7 +59,7 @@ describe('elementType tests', () => {
     const expected = 'UX:Slider';
     const actual = elementType(node);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct type of the multiple custom object element given its node object',
@@ -70,7 +70,7 @@ describe('elementType tests', () => {
       const expected = 'UX.Slider.Blue.Light';
       const actual = elementType(node);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
   it('should return this.Component when given its node object', () => {
@@ -80,6 +80,6 @@ describe('elementType tests', () => {
     const expected = 'this.Component';
     const actual = elementType(node);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });

--- a/__tests__/src/getProp-test.js
+++ b/__tests__/src/getProp-test.js
@@ -11,14 +11,14 @@ describe('getProp', () => {
     const expected = 'function';
     const actual = typeof getProp;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined if no arguments are provided', () => {
     const expected = undefined;
     const actual = getProp();
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined if the attribute is absent', () => {
@@ -30,7 +30,7 @@ describe('getProp', () => {
     const expected = undefined;
     const actual = getProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct attribute if the attribute exists', () => {
@@ -42,7 +42,7 @@ describe('getProp', () => {
     const expected = 'id';
     const actual = getProp(props, prop).name.name;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct attribute if the attribute exists in spread', () => {
@@ -54,7 +54,7 @@ describe('getProp', () => {
     const expected = 'id';
     const actual = getProp(props, prop).name.name;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return the correct attribute if the attribute exists in spread as an expression', () => {
@@ -68,8 +68,8 @@ describe('getProp', () => {
     const actualName = actual.name.name;
     const actualValue = actual.value.expression.name;
 
-    assert.equal(expected, actualName);
-    assert.equal(expected, actualValue);
+    assert.equal(actualName, expected);
+    assert.equal(actualValue, expected);
   });
 
   it('should return the correct attribute if the attribute exists in spread (case sensitive)', () => {
@@ -82,7 +82,7 @@ describe('getProp', () => {
     const expected = 'id';
     const actual = getProp(props, prop, options).name.name;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined if the attribute does not exist in spread (case sensitive)', () => {
@@ -95,7 +95,7 @@ describe('getProp', () => {
     const expected = undefined;
     const actual = getProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined for key in spread', () => {
@@ -108,7 +108,7 @@ describe('getProp', () => {
     const expected = undefined;
     const actual = getProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined if the attribute may exist in spread', () => {
@@ -120,7 +120,7 @@ describe('getProp', () => {
     const expected = undefined;
     const actual = getProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should not crash if the spread contains a spread', () => {
@@ -144,6 +144,6 @@ describe('getProp', () => {
     const expected = undefined;
     const actual = getProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });

--- a/__tests__/src/getPropLiteralValue-babelparser-test.js
+++ b/__tests__/src/getPropLiteralValue-babelparser-test.js
@@ -17,14 +17,14 @@ describe('getLiteralPropValue', () => {
     const expected = 'function';
     const actual = typeof getLiteralPropValue;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined when not provided with a JSXAttribute', () => {
     const expected = undefined;
     const actual = getLiteralPropValue(1);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should not throw error when trying to get value from unknown node type', () => {
@@ -59,7 +59,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -70,7 +70,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct string if value is a string expression', () => {
@@ -79,7 +79,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct integer if value is a integer expression', () => {
@@ -88,7 +88,7 @@ describe('getLiteralPropValue', () => {
       const expected = 1;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "true" to boolean type', () => {
@@ -97,7 +97,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "TrUE" to boolean type', () => {
@@ -106,7 +106,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "false" to boolean type', () => {
@@ -115,7 +115,7 @@ describe('getLiteralPropValue', () => {
       const expected = false;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "FaLsE" to boolean type', () => {
@@ -124,7 +124,7 @@ describe('getLiteralPropValue', () => {
       const expected = false;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return String null when value is null', () => {
@@ -133,7 +133,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'null';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -144,7 +144,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -155,7 +155,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when identifier is literally `undefined`', () => {
@@ -164,7 +164,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -175,7 +175,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -184,7 +184,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar undefined';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -195,7 +195,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -204,7 +204,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar undefined';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -215,7 +215,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -226,7 +226,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -237,7 +237,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return null for || operator', () => {
@@ -246,7 +246,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -257,7 +257,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -268,7 +268,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -280,7 +280,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with -', () => {
@@ -289,7 +289,7 @@ describe('getLiteralPropValue', () => {
       const expected = -42;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -299,7 +299,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -308,7 +308,7 @@ describe('getLiteralPropValue', () => {
       const expected = 42;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with !', () => {
@@ -317,7 +317,7 @@ describe('getLiteralPropValue', () => {
       const expected = false; // !"bar" === false
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with ~', () => {
@@ -326,7 +326,7 @@ describe('getLiteralPropValue', () => {
       const expected = -1; // ~"bar" === -1
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return true when evaluating `delete foo`', () => {
@@ -335,7 +335,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `void foo`', () => {
@@ -344,7 +344,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     // TODO: We should fix this to check to see if we can evaluate it.
@@ -354,7 +354,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -366,7 +366,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with --', () => {
@@ -376,7 +376,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with ++', () => {
@@ -386,7 +386,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with --', () => {
@@ -396,7 +396,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -407,7 +407,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -418,7 +418,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -429,7 +429,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -440,7 +440,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -451,7 +451,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -462,7 +462,7 @@ describe('getLiteralPropValue', () => {
       const expected = ['bar', 42];
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -472,7 +472,7 @@ describe('getLiteralPropValue', () => {
     const expected = [];
     const actual = getLiteralPropValue(prop);
 
-    assert.deepEqual(expected, actual);
+    assert.deepEqual(actual, expected);
   });
 
   describe('Bind expression', () => {
@@ -482,7 +482,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -497,7 +497,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
@@ -506,7 +506,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
@@ -516,7 +516,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/__tests__/src/getPropLiteralValue-flowparser-test.js
+++ b/__tests__/src/getPropLiteralValue-flowparser-test.js
@@ -17,14 +17,14 @@ describe('getLiteralPropValue', () => {
     const expected = 'function';
     const actual = typeof getLiteralPropValue;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined when not provided with a JSXAttribute', () => {
     const expected = undefined;
     const actual = getLiteralPropValue(1);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should not throw error when trying to get value from unknown node type', () => {
@@ -59,7 +59,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -70,7 +70,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct string if value is a string expression', () => {
@@ -79,7 +79,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct integer if value is a integer expression', () => {
@@ -88,7 +88,7 @@ describe('getLiteralPropValue', () => {
       const expected = 1;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "true" to boolean type', () => {
@@ -97,7 +97,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "TrUE" to boolean type', () => {
@@ -106,7 +106,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "false" to boolean type', () => {
@@ -115,7 +115,7 @@ describe('getLiteralPropValue', () => {
       const expected = false;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "FaLsE" to boolean type', () => {
@@ -124,7 +124,7 @@ describe('getLiteralPropValue', () => {
       const expected = false;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return String null when value is null', () => {
@@ -133,7 +133,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'null';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -144,7 +144,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -155,7 +155,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when identifier is literally `undefined`', () => {
@@ -164,7 +164,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -175,7 +175,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -184,7 +184,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar undefined';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -195,7 +195,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -204,7 +204,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'bar undefined';
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -215,7 +215,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -226,7 +226,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -237,7 +237,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return null for || operator', () => {
@@ -246,7 +246,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -257,7 +257,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -268,7 +268,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -280,7 +280,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with -', () => {
@@ -289,7 +289,7 @@ describe('getLiteralPropValue', () => {
       const expected = -42;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -299,7 +299,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -308,7 +308,7 @@ describe('getLiteralPropValue', () => {
       const expected = 42;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with !', () => {
@@ -317,7 +317,7 @@ describe('getLiteralPropValue', () => {
       const expected = false; // !"bar" === false
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with ~', () => {
@@ -326,7 +326,7 @@ describe('getLiteralPropValue', () => {
       const expected = -1; // ~"bar" === -1
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return true when evaluating `delete foo`', () => {
@@ -335,7 +335,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `void foo`', () => {
@@ -344,7 +344,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     // TODO: We should fix this to check to see if we can evaluate it.
@@ -354,7 +354,7 @@ describe('getLiteralPropValue', () => {
       const expected = undefined;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -366,7 +366,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with --', () => {
@@ -376,7 +376,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with ++', () => {
@@ -386,7 +386,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with --', () => {
@@ -396,7 +396,7 @@ describe('getLiteralPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getLiteralPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -407,7 +407,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -418,7 +418,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -429,7 +429,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -440,7 +440,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -451,7 +451,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -462,7 +462,7 @@ describe('getLiteralPropValue', () => {
       const expected = ['bar', 42];
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -472,7 +472,7 @@ describe('getLiteralPropValue', () => {
     const expected = [];
     const actual = getLiteralPropValue(prop);
 
-    assert.deepEqual(expected, actual);
+    assert.deepEqual(actual, expected);
   });
 
   describe('Bind expression', () => {
@@ -482,7 +482,7 @@ describe('getLiteralPropValue', () => {
       const expected = 'null';
       const actual = getLiteralPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -497,7 +497,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
@@ -506,7 +506,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
@@ -516,7 +516,7 @@ describe('getLiteralPropValue', () => {
       const expected = null;
       const actual = getLiteralPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/__tests__/src/getPropValue-babelparser-test.js
+++ b/__tests__/src/getPropValue-babelparser-test.js
@@ -18,14 +18,14 @@ describe('getPropValue', () => {
     const expected = 'function';
     const actual = typeof getPropValue;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined when not provided with a JSXAttribute', () => {
     const expected = undefined;
     const actual = getPropValue(1);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should not throw error when trying to get value from unknown node type', () => {
@@ -60,7 +60,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -71,7 +71,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct string if value is a string expression', () => {
@@ -80,7 +80,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct integer if value is a integer expression', () => {
@@ -89,7 +89,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "true" to boolean type', () => {
@@ -98,7 +98,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "false" to boolean type', () => {
@@ -107,7 +107,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -118,7 +118,7 @@ describe('getPropValue', () => {
       const expected = '<bar />';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -129,7 +129,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when identifier is literally `undefined`', () => {
@@ -138,7 +138,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return String object when using a reserved JavaScript object', () => {
@@ -147,7 +147,7 @@ describe('getPropValue', () => {
       const expected = String;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Array object when using a reserved JavaScript object', () => {
@@ -156,7 +156,7 @@ describe('getPropValue', () => {
       const expected = Array;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Date object when using a reserved JavaScript object', () => {
@@ -165,7 +165,7 @@ describe('getPropValue', () => {
       const expected = Date;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Infinity object when using a reserved JavaScript object', () => {
@@ -174,7 +174,7 @@ describe('getPropValue', () => {
       const expected = Infinity;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Math object when using a reserved JavaScript object', () => {
@@ -183,7 +183,7 @@ describe('getPropValue', () => {
       const expected = Math;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Number object when using a reserved JavaScript object', () => {
@@ -192,7 +192,7 @@ describe('getPropValue', () => {
       const expected = Number;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Object object when using a reserved JavaScript object', () => {
@@ -201,7 +201,7 @@ describe('getPropValue', () => {
       const expected = Object;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -212,7 +212,7 @@ describe('getPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -221,7 +221,7 @@ describe('getPropValue', () => {
       const expected = 'bar undefined';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return template literal with expression type wrapped in curly braces', () => {
@@ -230,7 +230,7 @@ describe('getPropValue', () => {
       const expected = 'bar {CallExpression}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should ignore non-expressions in the template literal', () => {
@@ -239,7 +239,7 @@ describe('getPropValue', () => {
       const expected = 'bar ';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -250,7 +250,7 @@ describe('getPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -259,7 +259,7 @@ describe('getPropValue', () => {
       const expected = 'bar undefined';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return template literal with expression type wrapped in curly braces', () => {
@@ -268,7 +268,7 @@ describe('getPropValue', () => {
       const expected = 'bar {CallExpression}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should ignore non-expressions in the template literal', () => {
@@ -277,7 +277,7 @@ describe('getPropValue', () => {
       const expected = 'bar ';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -327,7 +327,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `undefined && undefined` ', () => {
@@ -336,7 +336,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly infer result of || logical expression based on derived values', () => {
@@ -345,7 +345,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly infer result of || logical expression based on derived values', () => {
@@ -354,7 +354,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `undefined || undefined` ', () => {
@@ -363,7 +363,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly infer result of ?? logical expression based on derived values', () => {
@@ -373,7 +373,7 @@ describe('getPropValue', () => {
         const expected = 'bar';
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -391,7 +391,7 @@ describe('getPropValue', () => {
         const expected = 'baz';
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -409,7 +409,7 @@ describe('getPropValue', () => {
         const expected = undefined;
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -427,7 +427,7 @@ describe('getPropValue', () => {
         const expected = undefined;
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -445,7 +445,7 @@ describe('getPropValue', () => {
         const expected = null;
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -463,7 +463,7 @@ describe('getPropValue', () => {
         const expected = null;
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -482,7 +482,7 @@ describe('getPropValue', () => {
       const expected = 'bar.baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate to a correct representation of member expression with a nullable member', () => {
@@ -492,7 +492,7 @@ describe('getPropValue', () => {
         const expected = 'bar?.baz';
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -510,7 +510,7 @@ describe('getPropValue', () => {
         const expected = 'bar.baz?.(quux)';
         const actual = getPropValue(prop);
 
-        assert.equal(expected, actual);
+        assert.equal(actual, expected);
       };
 
       if (fallbackToBabylon) {
@@ -529,7 +529,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of callee', () => {
@@ -538,7 +538,7 @@ describe('getPropValue', () => {
       const expected = 'bar.call';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -550,7 +550,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with -', () => {
@@ -559,7 +559,7 @@ describe('getPropValue', () => {
       const expected = -42;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -569,7 +569,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -578,7 +578,7 @@ describe('getPropValue', () => {
       const expected = 42;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with !', () => {
@@ -587,7 +587,7 @@ describe('getPropValue', () => {
       const expected = false; // !"bar" === false
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with ~', () => {
@@ -596,7 +596,7 @@ describe('getPropValue', () => {
       const expected = -1; // ~"bar" === -1
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return true when evaluating `delete foo`', () => {
@@ -605,7 +605,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `void foo`', () => {
@@ -614,7 +614,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     // TODO: We should fix this to check to see if we can evaluate it.
@@ -624,7 +624,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -636,7 +636,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with --', () => {
@@ -645,7 +645,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with ++', () => {
@@ -655,7 +655,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with --', () => {
@@ -664,7 +664,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -675,7 +675,7 @@ describe('getPropValue', () => {
       const expected = 'this';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -686,7 +686,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the conditional based on the derived values correctly', () => {
@@ -695,7 +695,7 @@ describe('getPropValue', () => {
       const expected = 'bam';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the conditional based on the derived values correctly', () => {
@@ -704,7 +704,7 @@ describe('getPropValue', () => {
       const expected = 'bam';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -803,7 +803,7 @@ describe('getPropValue', () => {
       const expected = 4;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `>>` operator correctly', () => {
@@ -812,7 +812,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `>>>` operator correctly', () => {
@@ -821,7 +821,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `+` operator correctly', () => {
@@ -830,7 +830,7 @@ describe('getPropValue', () => {
       const expected = 2;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `-` operator correctly', () => {
@@ -839,7 +839,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `*` operator correctly', () => {
@@ -848,7 +848,7 @@ describe('getPropValue', () => {
       const expected = 100;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `/` operator correctly', () => {
@@ -857,7 +857,7 @@ describe('getPropValue', () => {
       const expected = 5;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `%` operator correctly', () => {
@@ -866,7 +866,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `|` operator correctly', () => {
@@ -875,7 +875,7 @@ describe('getPropValue', () => {
       const expected = 11;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `^` operator correctly', () => {
@@ -884,7 +884,7 @@ describe('getPropValue', () => {
       const expected = 11;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `&` operator correctly', () => {
@@ -893,7 +893,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `in` operator correctly', () => {
@@ -902,7 +902,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `instanceof` operator correctly', () => {
@@ -911,7 +911,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `instanceof` operator when right side is not a function', () => {
@@ -920,7 +920,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -931,7 +931,7 @@ describe('getPropValue', () => {
       const expected = { bar: 'baz' };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of the object, ignore spread properties', () => {
@@ -940,7 +940,7 @@ describe('getPropValue', () => {
       const expected = { bar: 'baz', baz: 'bar', foo: { bar: 'meh' } };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of the object, ignore spread properties', () => {
@@ -949,7 +949,7 @@ describe('getPropValue', () => {
       const expected = { pathname: 'manageRoute', state: {} };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -960,7 +960,7 @@ describe('getPropValue', () => {
       const expected = {};
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -971,7 +971,7 @@ describe('getPropValue', () => {
       const expected = ['bar', 42, null];
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of an array with spread elements', () => {
@@ -980,7 +980,7 @@ describe('getPropValue', () => {
       const expected = [undefined, 'bar'];
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -990,7 +990,7 @@ describe('getPropValue', () => {
     const expected = [];
     const actual = getPropValue(prop);
 
-    assert.deepEqual(expected, actual);
+    assert.deepEqual(actual, expected);
   });
 
   describe('Bind expression', () => {
@@ -1000,7 +1000,7 @@ describe('getPropValue', () => {
       const expected = 'this.handleClick.bind(this)';
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should return string representation of bind function call when object is not null', () => {
@@ -1009,7 +1009,7 @@ describe('getPropValue', () => {
       const expected = 'bar.bind(foo)';
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should return string representation of bind function call when binding to object properties', () => {
@@ -1022,7 +1022,7 @@ describe('getPropValue', () => {
       const otherExpected = 'a.b.c.bind(a.b)';
       const otherActual = getPropValue(otherProp);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
       assert.deepEqual(otherExpected, otherActual);
     });
   });
@@ -1057,7 +1057,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
@@ -1066,7 +1066,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
@@ -1076,7 +1076,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/__tests__/src/getPropValue-babelparser-test.js
+++ b/__tests__/src/getPropValue-babelparser-test.js
@@ -526,7 +526,7 @@ describe('getPropValue', () => {
     it('should return string representation of callee', () => {
       const prop = extractProp('<div foo={bar()} />');
 
-      const expected = 'bar';
+      const expected = 'bar()';
       const actual = getPropValue(prop);
 
       assert.equal(actual, expected);
@@ -535,7 +535,7 @@ describe('getPropValue', () => {
     it('should return string representation of callee', () => {
       const prop = extractProp('<div foo={bar.call()} />');
 
-      const expected = 'bar.call';
+      const expected = 'bar.call()';
       const actual = getPropValue(prop);
 
       assert.equal(actual, expected);

--- a/__tests__/src/getPropValue-flowparser-test.js
+++ b/__tests__/src/getPropValue-flowparser-test.js
@@ -17,14 +17,14 @@ describe('getPropValue', () => {
     const expected = 'function';
     const actual = typeof getPropValue;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return undefined when not provided with a JSXAttribute', () => {
     const expected = undefined;
     const actual = getPropValue(1);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should throw not error when trying to get value from unknown node type', () => {
@@ -59,7 +59,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -70,7 +70,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct string if value is a string expression', () => {
@@ -79,7 +79,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return correct integer if value is a integer expression', () => {
@@ -88,7 +88,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "true" to boolean type', () => {
@@ -97,7 +97,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should convert "false" to boolean type', () => {
@@ -106,7 +106,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -117,7 +117,7 @@ describe('getPropValue', () => {
       const expected = '<bar />';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -128,7 +128,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when identifier is literally `undefined`', () => {
@@ -137,7 +137,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return String object when using a reserved JavaScript object', () => {
@@ -146,7 +146,7 @@ describe('getPropValue', () => {
       const expected = String;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Array object when using a reserved JavaScript object', () => {
@@ -155,7 +155,7 @@ describe('getPropValue', () => {
       const expected = Array;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Date object when using a reserved JavaScript object', () => {
@@ -164,7 +164,7 @@ describe('getPropValue', () => {
       const expected = Date;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Infinity object when using a reserved JavaScript object', () => {
@@ -173,7 +173,7 @@ describe('getPropValue', () => {
       const expected = Infinity;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Math object when using a reserved JavaScript object', () => {
@@ -182,7 +182,7 @@ describe('getPropValue', () => {
       const expected = Math;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Number object when using a reserved JavaScript object', () => {
@@ -191,7 +191,7 @@ describe('getPropValue', () => {
       const expected = Number;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return Object object when using a reserved JavaScript object', () => {
@@ -200,7 +200,7 @@ describe('getPropValue', () => {
       const expected = Object;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -211,7 +211,7 @@ describe('getPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -220,7 +220,7 @@ describe('getPropValue', () => {
       const expected = 'bar undefined';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return template literal with expression type wrapped in curly braces', () => {
@@ -229,7 +229,7 @@ describe('getPropValue', () => {
       const expected = 'bar {CallExpression}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should ignore non-expressions in the template literal', () => {
@@ -238,7 +238,7 @@ describe('getPropValue', () => {
       const expected = 'bar ';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -249,7 +249,7 @@ describe('getPropValue', () => {
       const expected = 'bar {baz}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string "undefined" for expressions that evaluate to undefined', () => {
@@ -258,7 +258,7 @@ describe('getPropValue', () => {
       const expected = 'bar undefined';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return template literal with expression type wrapped in curly braces', () => {
@@ -267,7 +267,7 @@ describe('getPropValue', () => {
       const expected = 'bar {CallExpression}';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should ignore non-expressions in the template literal', () => {
@@ -276,7 +276,7 @@ describe('getPropValue', () => {
       const expected = 'bar ';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -326,7 +326,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `undefined && undefined` ', () => {
@@ -335,7 +335,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly infer result of || logical expression based on derived values', () => {
@@ -344,7 +344,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly infer result of || logical expression based on derived values', () => {
@@ -353,7 +353,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `undefined || undefined` ', () => {
@@ -362,7 +362,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -373,7 +373,7 @@ describe('getPropValue', () => {
       const expected = 'bar.baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate to a correct representation of member expression with a nullable member', () => {
@@ -382,7 +382,7 @@ describe('getPropValue', () => {
       const expected = 'bar?.baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -393,7 +393,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of callee', () => {
@@ -402,7 +402,7 @@ describe('getPropValue', () => {
       const expected = 'bar.call';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -414,7 +414,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with -', () => {
@@ -423,7 +423,7 @@ describe('getPropValue', () => {
       const expected = -42;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -433,7 +433,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with +', () => {
@@ -442,7 +442,7 @@ describe('getPropValue', () => {
       const expected = 42;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with !', () => {
@@ -451,7 +451,7 @@ describe('getPropValue', () => {
       const expected = false; // !"bar" === false
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with ~', () => {
@@ -460,7 +460,7 @@ describe('getPropValue', () => {
       const expected = -1; // ~"bar" === -1
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return true when evaluating `delete foo`', () => {
@@ -469,7 +469,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return undefined when evaluating `void foo`', () => {
@@ -478,7 +478,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     // TODO: We should fix this to check to see if we can evaluate it.
@@ -488,7 +488,7 @@ describe('getPropValue', () => {
       const expected = undefined;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -500,7 +500,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that prefixes with --', () => {
@@ -509,7 +509,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with ++', () => {
@@ -519,7 +519,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should correctly evaluate an expression that suffixes with --', () => {
@@ -528,7 +528,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = Number.isNaN(getPropValue(prop));
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -539,7 +539,7 @@ describe('getPropValue', () => {
       const expected = 'this';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -550,7 +550,7 @@ describe('getPropValue', () => {
       const expected = 'baz';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the conditional based on the derived values correctly', () => {
@@ -559,7 +559,7 @@ describe('getPropValue', () => {
       const expected = 'bam';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the conditional based on the derived values correctly', () => {
@@ -568,7 +568,7 @@ describe('getPropValue', () => {
       const expected = 'bam';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -667,7 +667,7 @@ describe('getPropValue', () => {
       const expected = 4;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `>>` operator correctly', () => {
@@ -676,7 +676,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `>>>` operator correctly', () => {
@@ -685,7 +685,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `+` operator correctly', () => {
@@ -694,7 +694,7 @@ describe('getPropValue', () => {
       const expected = 2;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `-` operator correctly', () => {
@@ -703,7 +703,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `*` operator correctly', () => {
@@ -712,7 +712,7 @@ describe('getPropValue', () => {
       const expected = 100;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `/` operator correctly', () => {
@@ -721,7 +721,7 @@ describe('getPropValue', () => {
       const expected = 5;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `%` operator correctly', () => {
@@ -730,7 +730,7 @@ describe('getPropValue', () => {
       const expected = 1;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `|` operator correctly', () => {
@@ -739,7 +739,7 @@ describe('getPropValue', () => {
       const expected = 11;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `^` operator correctly', () => {
@@ -748,7 +748,7 @@ describe('getPropValue', () => {
       const expected = 11;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `&` operator correctly', () => {
@@ -757,7 +757,7 @@ describe('getPropValue', () => {
       const expected = 0;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `in` operator correctly', () => {
@@ -766,7 +766,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `instanceof` operator correctly', () => {
@@ -775,7 +775,7 @@ describe('getPropValue', () => {
       const expected = true;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should evaluate the `instanceof` operator when right side is not a function', () => {
@@ -784,7 +784,7 @@ describe('getPropValue', () => {
       const expected = false;
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 
@@ -795,7 +795,7 @@ describe('getPropValue', () => {
       const expected = { bar: 'baz' };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of the object, ignore spread properties', () => {
@@ -804,7 +804,7 @@ describe('getPropValue', () => {
       const expected = { bar: 'baz', baz: 'bar', foo: { bar: 'meh' } };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of the object, ignore spread properties', () => {
@@ -813,7 +813,7 @@ describe('getPropValue', () => {
       const expected = { pathname: 'manageRoute', state: {} };
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -824,7 +824,7 @@ describe('getPropValue', () => {
       const expected = {};
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -835,7 +835,7 @@ describe('getPropValue', () => {
       const expected = ['bar', 42, null];
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
 
     it('should evaluate to a correct representation of an array with spread elements', () => {
@@ -844,7 +844,7 @@ describe('getPropValue', () => {
       const expected = [undefined, 'bar'];
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -854,7 +854,7 @@ describe('getPropValue', () => {
     const expected = [];
     const actual = getPropValue(prop);
 
-    assert.deepEqual(expected, actual);
+    assert.deepEqual(actual, expected);
   });
 
   describe('Bind expression', () => {
@@ -898,7 +898,7 @@ describe('getPropValue', () => {
       const expected = 'this.handleClick';
       const actual = getPropValue(prop);
 
-      assert.deepEqual(expected, actual);
+      assert.deepEqual(actual, expected);
     });
   });
 
@@ -913,7 +913,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a deep Typescript non-null assertion', () => {
@@ -922,7 +922,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
 
     it('should return string representation of variable identifier wrapped in a Typescript type coercion', () => {
@@ -932,7 +932,7 @@ describe('getPropValue', () => {
       const expected = 'bar';
       const actual = getPropValue(prop);
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/__tests__/src/getPropValue-flowparser-test.js
+++ b/__tests__/src/getPropValue-flowparser-test.js
@@ -390,7 +390,7 @@ describe('getPropValue', () => {
     it('should return string representation of callee', () => {
       const prop = extractProp('<div foo={bar()} />');
 
-      const expected = 'bar';
+      const expected = 'bar()';
       const actual = getPropValue(prop);
 
       assert.equal(actual, expected);
@@ -399,7 +399,7 @@ describe('getPropValue', () => {
     it('should return string representation of callee', () => {
       const prop = extractProp('<div foo={bar.call()} />');
 
-      const expected = 'bar.call';
+      const expected = 'bar.call()';
       const actual = getPropValue(prop);
 
       assert.equal(actual, expected);

--- a/__tests__/src/hasProp-test.js
+++ b/__tests__/src/hasProp-test.js
@@ -11,14 +11,14 @@ describe('hasProp', () => {
     const expected = 'function';
     const actual = typeof hasProp;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if no arguments are provided', () => {
     const expected = false;
     const actual = hasProp();
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is absent', () => {
@@ -30,7 +30,7 @@ describe('hasProp', () => {
     const expected = false;
     const actual = hasProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the prop exists', () => {
@@ -42,7 +42,7 @@ describe('hasProp', () => {
     const expected = true;
     const actual = hasProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the prop may exist in spread loose mode', () => {
@@ -57,7 +57,7 @@ describe('hasProp', () => {
     const expected = true;
     const actual = hasProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is considered absent in case-sensitive mode', () => {
@@ -72,7 +72,7 @@ describe('hasProp', () => {
     const expected = false;
     const actual = hasProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });
 
@@ -81,14 +81,14 @@ describe('hasAnyProp tests', () => {
     const expected = 'function';
     const actual = typeof hasAnyProp;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if no arguments are provided', () => {
     const expected = false;
     const actual = hasAnyProp();
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is absent', () => {
@@ -100,7 +100,7 @@ describe('hasAnyProp tests', () => {
     const expected = false;
     const actual = hasAnyProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are absent in array', () => {
@@ -112,7 +112,7 @@ describe('hasAnyProp tests', () => {
     const expected = false;
     const actual = hasAnyProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are absent in space delimited string', () => {
@@ -124,7 +124,7 @@ describe('hasAnyProp tests', () => {
     const expected = false;
     const actual = hasAnyProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the prop exists', () => {
@@ -136,7 +136,7 @@ describe('hasAnyProp tests', () => {
     const expected = true;
     const actual = hasAnyProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if any prop exists in array', () => {
@@ -148,7 +148,7 @@ describe('hasAnyProp tests', () => {
     const expected = true;
     const actual = hasAnyProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if any prop exists in space delimited string', () => {
@@ -160,7 +160,7 @@ describe('hasAnyProp tests', () => {
     const expected = true;
     const actual = hasAnyProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the prop may exist in spread loose mode', () => {
@@ -175,7 +175,7 @@ describe('hasAnyProp tests', () => {
     const expected = true;
     const actual = hasAnyProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if any prop may exist in spread loose mode', () => {
@@ -190,7 +190,7 @@ describe('hasAnyProp tests', () => {
     const expected = true;
     const actual = hasAnyProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is considered absent in case-sensitive mode', () => {
@@ -205,7 +205,7 @@ describe('hasAnyProp tests', () => {
     const expected = false;
     const actual = hasAnyProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are considered absent in case-sensitive mode', () => {
@@ -220,7 +220,7 @@ describe('hasAnyProp tests', () => {
     const expected = false;
     const actual = hasAnyProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });
 
@@ -229,14 +229,14 @@ describe('hasEveryProp tests', () => {
     const expected = 'function';
     const actual = typeof hasEveryProp;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if no arguments are provided', () => {
     const expected = true;
     const actual = hasEveryProp();
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is absent', () => {
@@ -248,7 +248,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if any props are absent in array', () => {
@@ -260,7 +260,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are absent in array', () => {
@@ -272,7 +272,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if any props are absent in space delimited string', () => {
@@ -284,7 +284,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are absent in space delimited string', () => {
@@ -296,7 +296,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, propsToCheck);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the prop exists', () => {
@@ -308,7 +308,7 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if all props exist in array', () => {
@@ -320,7 +320,7 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if all props exist in space delimited string', () => {
@@ -332,7 +332,7 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if the props may exist in spread loose mode', () => {
@@ -347,7 +347,7 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if all props may exist in spread loose mode', () => {
@@ -362,7 +362,7 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if the prop is considered absent in case-sensitive mode', () => {
@@ -377,7 +377,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return false if all props are considered absent in case-sensitive mode', () => {
@@ -392,7 +392,7 @@ describe('hasEveryProp tests', () => {
     const expected = false;
     const actual = hasEveryProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return true if all props are considered present in case-sensitive mode', () => {
@@ -407,6 +407,6 @@ describe('hasEveryProp tests', () => {
     const expected = true;
     const actual = hasEveryProp(props, prop, options);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });

--- a/__tests__/src/index-test.js
+++ b/__tests__/src/index-test.js
@@ -13,7 +13,7 @@ describe('main export', () => {
     const expected = 'object';
     const actual = typeof core;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   src.filter((f) => f !== 'index').forEach((f) => {
@@ -29,7 +29,7 @@ describe('main export', () => {
       const expected = true;
       const actual = fs.statSync(path.join(path.resolve('.'), file)).isFile();
 
-      assert.equal(expected, actual);
+      assert.equal(actual, expected);
     });
   });
 });

--- a/__tests__/src/propName-test.js
+++ b/__tests__/src/propName-test.js
@@ -11,7 +11,7 @@ describe('propName', () => {
     const expected = 'function';
     const actual = typeof propName;
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should throw an error if the argument is missing', () => {
@@ -28,7 +28,7 @@ describe('propName', () => {
     const expected = 'foo';
     const actual = propName(prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 
   it('should return correct name for namespaced prop', () => {
@@ -37,6 +37,6 @@ describe('propName', () => {
     const expected = 'foo:bar';
     const actual = propName(prop);
 
-    assert.equal(expected, actual);
+    assert.equal(actual, expected);
   });
 });

--- a/package.json
+++ b/package.json
@@ -15,8 +15,8 @@
     "test:watch": "npm run tests-only -- --watch"
   },
   "devDependencies": {
-    "@babel/core": "^7.10.2",
-    "@babel/parser": "^7.10.2",
+    "@babel/core": "^7.11.6",
+    "@babel/parser": "^7.11.5",
     "babel-cli": "^6.26.0",
     "babel-core": "^6.26.3",
     "babel-eslint": "^10.1.0",
@@ -27,9 +27,9 @@
     "babel-preset-env": "^1.7.0",
     "babylon": "^6.18.0",
     "coveralls": "^3.1.0",
-    "eslint": "^7.2.0",
+    "eslint": "^7.8.1",
     "eslint-config-airbnb-base": "^14.2.0",
-    "eslint-plugin-import": "^2.21.2",
+    "eslint-plugin-import": "^2.22.0",
     "flow-parser": "^0.126.1",
     "in-publish": "^2.0.1",
     "jest": "^20.0.4",

--- a/src/values/expressions/CallExpression.js
+++ b/src/values/expressions/CallExpression.js
@@ -10,5 +10,6 @@
 export default function extractValueFromCallExpression(value) {
   // eslint-disable-next-line global-require
   const getValue = require('./index.js').default;
-  return getValue(value.callee);
+  const args = Array.isArray(value.arguments) ? value.arguments.map((x) => getValue(x)).join(', ') : '';
+  return `${getValue(value.callee)}${value.optional ? '?.' : ''}(${args})`;
 }

--- a/src/values/expressions/ChainExpression.js
+++ b/src/values/expressions/ChainExpression.js
@@ -1,0 +1,13 @@
+/**
+ * Extractor function for a ChainExpression type value node.
+ * A member expression is accessing a property on an object `obj.property`.
+ *
+ * @param - value - AST Value object with type `ChainExpression`
+ * @returns - The extracted value converted to correct type
+ *  and maintaing `obj?.property` convention.
+ */
+export default function extractValueFromChainExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
+  return getValue(value.expression);
+}

--- a/src/values/expressions/MemberExpression.js
+++ b/src/values/expressions/MemberExpression.js
@@ -9,5 +9,5 @@
 export default function extractValueFromMemberExpression(value) {
   // eslint-disable-next-line global-require
   const getValue = require('./index.js').default;
-  return `${getValue(value.object)}.${getValue(value.property)}`;
+  return `${getValue(value.object)}${value.optional ? '?.' : '.'}${getValue(value.property)}`;
 }

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -6,6 +6,7 @@ import TemplateLiteral from './TemplateLiteral';
 import FunctionExpression from './FunctionExpression';
 import LogicalExpression from './LogicalExpression';
 import MemberExpression from './MemberExpression';
+import ChainExpression from './ChainExpression';
 import OptionalCallExpression from './OptionalCallExpression';
 import OptionalMemberExpression from './OptionalMemberExpression';
 import CallExpression from './CallExpression';
@@ -32,6 +33,7 @@ const TYPES = {
   FunctionExpression,
   LogicalExpression,
   MemberExpression,
+  ChainExpression,
   OptionalCallExpression,
   OptionalMemberExpression,
   CallExpression,


### PR DESCRIPTION
Tests are currently failing on master.

This PR fixes those tests, but in so doing, causes a potential breaking change - CallExpressions now include the invocation parens, and when available, the arguments.

It's not yet clear if this will break eslint-plugin-jsx-a11y; i'll test it with that and hopefully that will help inform if this is breaking or not.

Fixes #103.