### PR TITLE
Implement ChainExpression type and update MemberExpression

### DIFF
--- a/src/values/expressions/ChainExpression.js
+++ b/src/values/expressions/ChainExpression.js
@@ -1,0 +1,12 @@
+/**
+ * Extractor function for a ChainExpression type value node.
+ * A member expression is accessing a property on an object `obj.property`.
+ *
+ * @param - value - AST Value object with type `ChainExpression`
+ * @returns - The extracted value converted to correct type
+ */
+export default function extractValueFromChainExpression(value) {
+  // eslint-disable-next-line global-require
+  const getValue = require('./index.js').default;
+  return getValue(value.expression);
+}

--- a/src/values/expressions/MemberExpression.js
+++ b/src/values/expressions/MemberExpression.js
@@ -4,10 +4,12 @@
  *
  * @param - value - AST Value object with type `MemberExpression`
  * @returns - The extracted value converted to correct type
- *  and maintaing `obj.property` convention.
+ *  and maintaing `obj.property` convention,
+ * or `obj?.property` if it occurs in a `ChainExpression`.
  */
 export default function extractValueFromMemberExpression(value) {
   // eslint-disable-next-line global-require
   const getValue = require('./index.js').default;
-  return `${getValue(value.object)}.${getValue(value.property)}`;
+  const separator = value.optional ? '?.' : '.';
+  return `${getValue(value.object)}${separator}${getValue(value.property)}`;
 }

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -6,6 +6,7 @@ import TemplateLiteral from './TemplateLiteral';
 import FunctionExpression from './FunctionExpression';
 import LogicalExpression from './LogicalExpression';
 import MemberExpression from './MemberExpression';
+import ChainExpression from './ChainExpression';
 import OptionalCallExpression from './OptionalCallExpression';
 import OptionalMemberExpression from './OptionalMemberExpression';
 import CallExpression from './CallExpression';
@@ -32,6 +33,7 @@ const TYPES = {
   FunctionExpression,
   LogicalExpression,
   MemberExpression,
+  ChainExpression,
   OptionalCallExpression,
   OptionalMemberExpression,
   CallExpression,


### PR DESCRIPTION
Fixes #103 

See https://github.com/estree/estree/blob/master/es2020.md#chainexpression for reference, or this [really long implementation thread](https://github.com/eslint/eslint/pull/13416 ) at estree for background on how this AST design evolved from the earlier babel efforts implemented in #98.

To implement this, I looked at the current behavior of OptionalCallExpression and OptionalMemberExpression. I was able to preserve the output of OptionalMemberExpression, but the current output for OptionalCallExpression and CallExpression are very divergent: CallExpression prints the function name, while OptionalCallExpression prints the function name and argument values.

Please advise on which approach is preferred.

This is my first PR to this repo, so please offer any change requests, and I'd be happy to make them! Thank you for your time and consideration.