### PR TITLE
The literal value for a ChainExpression should be a noop

### DIFF
--- a/__tests__/src/getPropLiteralValue-babelparser-test.js
+++ b/__tests__/src/getPropLiteralValue-babelparser-test.js
@@ -168,6 +168,17 @@ describe('getLiteralPropValue', () => {
     });
   });
 
+  describeIfNotBabylon('Chain Expression', () => {
+    it('should return null', () => {
+      const prop = extractProp('<div foo={abc?.def} />');
+
+      const expected = null;
+      const actual = getLiteralPropValue(prop);
+
+      assert.equal(actual, expected);
+    });
+  });
+
   describe('Template literal', () => {
     it('should return template literal with vars wrapped in curly braces', () => {
       const prop = extractProp('<div foo={`bar ${baz}`} />');

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -156,6 +156,7 @@ const LITERAL_TYPES = {
   TSAsExpression: noop,
   TypeCastExpression: noop,
   SequenceExpression: noop,
+  ChainExpression: noop,
 };
 
 /**


### PR DESCRIPTION
Just like a `MemberExpression`, the literal value of a `ChainExpression` should be a noop, otherwise it returns the expression itself as if it were a string. 