### PR TITLE
[patch] include project name in error logging

### DIFF
--- a/.eslintignore
+++ b/.eslintignore
@@ -1,3 +1,4 @@
 node_modules/
 reports/
 lib/
+coverage/

--- a/src/values/expressions/TSNonNullExpression.js
+++ b/src/values/expressions/TSNonNullExpression.js
@@ -12,7 +12,7 @@ const extractValueFromThisExpression = require('./ThisExpression').default;
 export default function extractValueFromTSNonNullExpression(value) {
   // eslint-disable-next-line global-require
   // const getValue = require('.').default;
-  const errorMessage = 'The prop value with an expression type of TSNonNullExpression could not be resolved. Please file issue to get this fixed immediately.';
+  const errorMessage = 'The prop value with an expression type of TSNonNullExpression could not be resolved. Please file an issue ( https://github.com/jsx-eslint/jsx-ast-utils/issues/new ) to get this fixed immediately.';
 
   // it's just the name
   if (value.type === 'Identifier') {

--- a/src/values/expressions/index.js
+++ b/src/values/expressions/index.js
@@ -58,7 +58,7 @@ const TYPES = {
 
 const noop = () => null;
 
-const errorMessage = (expression) => `The prop value with an expression type of ${expression} could not be resolved. Please file issue to get this fixed immediately.`;
+const errorMessage = (expression) => `The prop value with an expression type of ${expression} could not be resolved. Please file an issue ( https://github.com/jsx-eslint/jsx-ast-utils/issues/new ) to get this fixed immediately.`;
 
 /**
  * This function maps an AST value node


### PR DESCRIPTION
Adds project name in the error logs of unexpected nodes.

Currently it is not clear which utility is logging these errors. I've seen couple of reports where developers (including myself) were not sure where bug reports should be filed to.