### PR TITLE
[Deps] remove object.assign

### DIFF
--- a/package.json
+++ b/package.json
@@ -68,7 +68,6 @@
     ]
   },
   "dependencies": {
-    "array-includes": "^3.1.3",
-    "object.assign": "^4.1.2"
+    "array-includes": "^3.1.3"
   }
 }

--- a/src/values/expressions/ObjectExpression.js
+++ b/src/values/expressions/ObjectExpression.js
@@ -1,5 +1,3 @@
-import assign from 'object.assign';
-
 /**
  * Extractor function for an ObjectExpression type value node.
  * An object expression is using {}.
@@ -14,7 +12,7 @@ export default function extractValueFromObjectExpression(value) {
     // Support types: SpreadProperty and ExperimentalSpreadProperty
     if (/^(?:Experimental)?Spread(?:Property|Element)$/.test(property.type)) {
       if (property.argument.type === 'ObjectExpression') {
-        return assign(object, extractValueFromObjectExpression(property.argument));
+        return Object.assign(object, extractValueFromObjectExpression(property.argument));
       }
     } else {
       object[getValue(property.key)] = getValue(property.value);


### PR DESCRIPTION
Node.js 4+ support Object.assign() natively:
https://developer.mozilla.org/en-US/docs/Web/JavaScript/Reference/Global_Objects/Object/assign