### PR TITLE
[Fix]: `ArrayExpression`: handle sparse array

### DIFF
--- a/__tests__/src/getPropValue-babelparser-test.js
+++ b/__tests__/src/getPropValue-babelparser-test.js
@@ -996,9 +996,9 @@ describe('getPropValue', () => {
 
   describe('Array expression', () => {
     it('should evaluate to correct representation of the the array in props', () => {
-      const prop = extractProp('<div foo={["bar", 42, null]} />');
+      const prop = extractProp('<div foo={["bar", 42, , null]} />');
 
-      const expected = ['bar', 42, null];
+      const expected = ['bar', 42, undefined, null];
       const actual = getPropValue(prop);
 
       assert.deepEqual(actual, expected);

--- a/src/values/expressions/ArrayExpression.js
+++ b/src/values/expressions/ArrayExpression.js
@@ -7,5 +7,8 @@
 export default function extractValueFromArrayExpression(value) {
   // eslint-disable-next-line global-require
   const getValue = require('.').default;
-  return value.elements.map((element) => getValue(element));
+  return value.elements.map((element) => {
+    if (element === null) return undefined;
+    return getValue(element);
+  });
 }


### PR DESCRIPTION
Fix `TypeError: Cannot read properties of null (reading 'expression')` error when there are sparse array in props.