### PR TITLE
[Fix] Handle `as` casts in `TSNonNullExpression`

### DIFF
--- a/CHANGELOG.md
+++ b/CHANGELOG.md
@@ -1,5 +1,6 @@
 Unreleased
 ==================
+- [Fix] Handle `as` casts in TSNonNullExpression
 
 3.3.1 / 2022-06-22
 ==================

--- a/__tests__/src/getPropValue-babelparser-test.js
+++ b/__tests__/src/getPropValue-babelparser-test.js
@@ -1183,6 +1183,13 @@ describe('getPropValue', () => {
       assert.equal(actual, expected);
     });
 
+    it('should return string representation of a cast wrapped in a deep Typescript non-null assertion', () => {
+      const prop = extractProp('<div foo={(bar as Bar).baz!} />');
+      const actual = getPropValue(prop);
+      const expected = 'bar.baz!';
+      assert.equal(actual, expected);
+    });
+
     it('should return string representation of an object wrapped in a deep Typescript non-null assertion', () => {
       const prop = extractProp('<div foo={(bar.bar)!} />');
       const expected = '(bar.bar)!';

--- a/src/values/expressions/TSNonNullExpression.js
+++ b/src/values/expressions/TSNonNullExpression.js
@@ -31,6 +31,10 @@ export default function extractValueFromTSNonNullExpression(value) {
     return value.value;
   }
 
+  if (value.type === 'TSAsExpression') {
+    return extractValueFromTSNonNullExpression(value.expression);
+  }
+
   if (value.type === 'ThisExpression') {
     return extractValueFromThisExpression();
   }


### PR DESCRIPTION
Came here from a warning emitted by `eslint-plugin-jsx-a11y` in our (@waldoapp) codebase.